### PR TITLE
bugfix: ObjectDisposedException was thrown when CTRL+W was pressed

### DIFF
--- a/OleViewDotNet.Main/Forms/TypeLibControl.cs
+++ b/OleViewDotNet.Main/Forms/TypeLibControl.cs
@@ -398,6 +398,7 @@ namespace OleViewDotNet.Forms
 
         private void textBoxFilter_KeyUp(object sender, KeyEventArgs e)
         {
+            if (IsDisposed) return;
             RefreshInterfaces();
         }
     }


### PR DESCRIPTION
in the TypeLibControl view while quick filter had the focus