### PR TITLE
Fix error parsing CLSID of registered classes in x86 process

### DIFF
--- a/OleViewDotNet.Main/COMProcessParser.cs
+++ b/OleViewDotNet.Main/COMProcessParser.cs
@@ -1540,7 +1540,9 @@ namespace OleViewDotNet
         struct CClassEntry32 : ICClassEntry
         {
             public int vfptr; // CClassCache::CCollectableVtbl* 
+            private int padding1;
             public int _pNextCollectee; // CClassCache::CCollectable* 
+            private int padding2;
             public ulong _qwTickLastTouched;
 
             // SMultiGUIDHashNode _hashNode;


### PR DESCRIPTION
During the parsing of COM classes registered in the x86 process, an error occurs due to which the displayed data is incorrect. To reproduce the problem, do the following:
1. Start COM-object hosted in Wow64 process
```
$c = Get-ComClass -Clsid 0002df01-0000-0000-c000-000000000046
$o = New-ComObject -Class $c
```
2. Get process name, in which COM-object is hosted
```
$c.DefaultServer
C:\Program Files (x86)\Internet Explorer\ielowutil.exe
```
3. Parse COM-clasess registered in process
```
Get-ComProcess -Name ielowutil -ParseRegisteredClasses | Select Classes
Classes
-------
{Class: 00000002-a160-037e-01df-020000000000}
```
Obviously, result 00000002-a160-037e-01df-020000000000 is incorrect, expected result is 0002df01-0000-0000-c000-000000000046.

I checked on Windows 7, 8, 10 in 32-bit combase.dll the CClassCache::CClassEntry structure has a slightly different layout than the one described in COMProcessParser.cs. There are paddings for which there are no xrefs:

![image](https://user-images.githubusercontent.com/78100372/106185748-45eb7b00-61b4-11eb-839c-53ece74620c9.png)