### PR TITLE
Fix error parsing classes registered in STA in x86 process from x64

### DIFF
--- a/OleViewDotNet.Main/COMProcessParser.cs
+++ b/OleViewDotNet.Main/COMProcessParser.cs
@@ -2340,11 +2340,23 @@ namespace OleViewDotNet
             {
                 return IntPtr.Zero;
             }
+
+            int reservedForOleOffset;
             if (process.Is64Bit)
             {
-                return ReadPointer(process, teb + 0x1758);
+                reservedForOleOffset = 0x1758;
             }
-            return ReadPointer(process, teb + 0xF80);
+            else
+            {
+                reservedForOleOffset = 0xF80;
+                if (Environment.Is64BitProcess)
+                {
+                    teb += 0x2000;  // teb32. Magic constant is taken from
+                                    // https://github.com/DarthTon/Blackbone/blob/607e9a3be9ca01133de2b190f2efb17b3d51db40/src/BlackBone/Subsystem/NativeSubsystem.cpp#L378
+                }
+            }
+
+            return ReadPointer(process, teb + reservedForOleOffset);
         }
 
         private static string ReadUnicodeString(NtProcess process, IntPtr ptr)


### PR DESCRIPTION
The 64-bit powershell cannot properly parse COM classes registered in STA apartments in the x86 process. This is due to the fact that the field _ReservedForOle_ is important for this parsing and it is retrieved from the thread's TEB64. But registering COM class in STA apartment initializes this field in the TEB32.
Steps to reproduce:
1. Run the following commands in 32-bit powershell:
```
$c = Get-ComClass 2e7c0a19-0438-41e9-81e3-3ad3d64f55ba
$o = New-ComObject $c
(Get-ComProcess -Name OneDrive -ParseRegisteredClasses).Classes | Select ProcessId, ProcessName, Name, Clsid, Registered, Apartment | Format-Table
```
2. Look at the probably correct result:
```
ProcessID ProcessName Name                                        Clsid                                Registered Apartment
     7112 OneDrive    SyncEngineStorageProviderHandlerProxy Class a3ca1cf4-5f3e-4ac0-91b9-0d3716e1eac3       True       MTA
     7112 OneDrive    SyncEngineCOMServer Class                   ab807329-7324-431b-8b36-dbd581f56e0b       True       MTA
     7112 OneDrive    BannerNotificationHandler Class             2e7c0a19-0438-41e9-81e3-3ad3d64f55ba       True       STA
     7112 OneDrive    FileSyncClient AutoPlayHandler Class        5999e1ee-711e-48d2-9884-851a709f543d       True       STA
     7112 OneDrive    ToastActivator Class                        6bb93b4e-44d8-40e2-bd97-42dbcf18a40f       True       STA
     7112 OneDrive    FileSyncClient Class                        7b37e4e2-c62f-4914-9620-8fb5062718cc       True       STA
```
3. Now run the following command in 64-bit powershell.exe:
`(Get-ComProcess -Name OneDrive -ParseRegisteredClasses).Classes | Select ProcessId, ProcessName, Name, Clsid, Registered, Apartment | Format-Table`
4. Look at the exact wrong result - there are no COM classes registered in STA apartments:
```
ProcessID ProcessName Name Clsid                                Registered Apartment
     7112 OneDrive         a3ca1cf4-5f3e-4ac0-91b9-0d3716e1eac3      False       MTA
     7112 OneDrive         ab807329-7324-431b-8b36-dbd581f56e0b      False       MTA
```