### PR TITLE
Fix typo parameter in cmdlet Compare-ComDatabase and improve TEB32 ca…

### DIFF
--- a/OleViewDotNet.Main/COMProcessParser.cs
+++ b/OleViewDotNet.Main/COMProcessParser.cs
@@ -2351,8 +2351,16 @@ namespace OleViewDotNet
                 reservedForOleOffset = 0xF80;
                 if (Environment.Is64BitProcess)
                 {
-                    teb += 0x2000;  // teb32. Magic constant is taken from
-                                    // https://github.com/DarthTon/Blackbone/blob/607e9a3be9ca01133de2b190f2efb17b3d51db40/src/BlackBone/Subsystem/NativeSubsystem.cpp#L378
+                    if (COMUtilities.IsWindows81OrLess)
+                    {
+                        teb += 0x2000;  // teb32. Magic constant is taken from
+                                        // https://github.com/DarthTon/Blackbone/blob/607e9a3be9ca01133de2b190f2efb17b3d51db40/src/BlackBone/Subsystem/NativeSubsystem.cpp#L378
+                    }
+                    else
+                    {
+                        var wowTebOffset = process.ReadMemory<long>(teb.ToInt64() + 0x180C);
+                        teb = new IntPtr(teb.ToInt64() + wowTebOffset);
+                    }
                 }
             }
 

--- a/OleViewDotNet.PowerShell/OleViewDotNet.psm1
+++ b/OleViewDotNet.PowerShell/OleViewDotNet.psm1
@@ -378,7 +378,7 @@ function Compare-ComDatabase {
         [Parameter(Mandatory, Position = 1)]
         [OleViewDotNet.Database.COMRegistry]$Right,
         [OleViewDotNet.Database.COMRegistryDiffMode]$DiffMode = "LeftOnly",
-        [switch]$NoProgresss
+        [switch]$NoProgress
     )
     $callback = New-CallbackProgress -Activity "Comparing COM Registries" -NoProgress:$NoProgress
     [OleViewDotNet.Database.COMRegistry]::Diff($Left, $Right, $DiffMode, $callback)


### PR DESCRIPTION
1. Fixed typo in cmdlet Compare-ComDatabase parameter NoProgress
2. Improved calculation of TEB32 offset for Windows 10 and later