### PR TITLE
Add and forward server type param from Get-ComClassInterface cmdlet to OOP interface querying

### DIFF
--- a/OleViewDotNet.Main/COMUtilities.cs
+++ b/OleViewDotNet.Main/COMUtilities.cs
@@ -2214,7 +2214,7 @@ namespace OleViewDotNet
                 try
                 {
                     query_progress.Report();
-                    clsid.LoadSupportedInterfaces(false, null);
+                    clsid.LoadSupportedInterfaces(false, null, COMServerType.UnknownServer);
                 }
                 catch
                 {

--- a/OleViewDotNet.Main/Database/COMEnumerateInterfaces.cs
+++ b/OleViewDotNet.Main/Database/COMEnumerateInterfaces.cs
@@ -352,7 +352,7 @@ namespace OleViewDotNet.Database
             _winrt_component = !string.IsNullOrWhiteSpace(_activatable_classid);
         }
 
-        public async static Task<COMEnumerateInterfaces> GetInterfacesOOP(COMRuntimeClassEntry ent, COMRegistry registry, NtToken token)
+        public async static Task<COMEnumerateInterfaces> GetInterfacesOOP(COMRuntimeClassEntry ent, COMRegistry registry, NtToken token, COMServerType serverType)
         {
             string apartment = "s";
             if (ent.Threading == ThreadingType.Both
@@ -500,7 +500,7 @@ namespace OleViewDotNet.Database
             }
         }
 
-        public async static Task<COMEnumerateInterfaces> GetInterfacesOOP(COMCLSIDEntry ent, COMRegistry registry, NtToken token)
+        public async static Task<COMEnumerateInterfaces> GetInterfacesOOP(COMCLSIDEntry ent, COMRegistry registry, NtToken token, COMServerType serverType)
         {
             string apartment = "s";
             if (ent.DefaultThreadingModel == COMThreadingModel.Both 
@@ -509,9 +509,15 @@ namespace OleViewDotNet.Database
                 apartment = "m";
             }
 
-            string command_line = string.Format("{0} {1} \"{2}\"", ent.Clsid.ToString("B"), apartment, ent.CreateContext);
+            CLSCTX createCtx;
+            if (serverType == COMServerType.UnknownServer)
+                createCtx = ent.CreateContext;
+            else
+                createCtx = COMCLSIDEntry.ServerTypeToClsCtx(serverType);
+
+            string command_line = string.Format("{0} {1} \"{2}\"", ent.Clsid.ToString("B"), apartment, createCtx);
             var interfaces = await GetInterfacesOOP(command_line, false, registry, token);
-            return new COMEnumerateInterfaces(ent.Clsid, ent.CreateContext, string.Empty, interfaces.Interfaces, interfaces.FactoryInterfaces);
+            return new COMEnumerateInterfaces(ent.Clsid, createCtx, string.Empty, interfaces.Interfaces, interfaces.FactoryInterfaces);
         }
     }
 }

--- a/OleViewDotNet.Main/Database/COMRuntimeClassEntry.cs
+++ b/OleViewDotNet.Main/Database/COMRuntimeClassEntry.cs
@@ -259,11 +259,11 @@ namespace OleViewDotNet.Database
             return Server.CompareTo(other.Server);
         }
 
-        private async Task<COMEnumerateInterfaces> GetSupportedInterfacesInternal(NtToken token)
+        private async Task<COMEnumerateInterfaces> GetSupportedInterfacesInternal(NtToken token, COMServerType serverType)
         {
             try
             {
-                return await COMEnumerateInterfaces.GetInterfacesOOP(this, m_registry, token);
+                return await COMEnumerateInterfaces.GetInterfacesOOP(this, m_registry, token, serverType);
             }
             catch (Win32Exception)
             {
@@ -271,11 +271,11 @@ namespace OleViewDotNet.Database
             }
         }
 
-        public async Task<bool> LoadSupportedInterfacesAsync(bool refresh, NtToken token)
+        public async Task<bool> LoadSupportedInterfacesAsync(bool refresh, NtToken token, COMServerType serverType)
         {
             if (refresh || !InterfacesLoaded)
             {
-                COMEnumerateInterfaces enum_int = await GetSupportedInterfacesInternal(token);
+                COMEnumerateInterfaces enum_int = await GetSupportedInterfacesInternal(token, serverType);
                 m_interfaces = new List<COMInterfaceInstance>(enum_int.Interfaces);
                 m_factory_interfaces = new List<COMInterfaceInstance>(enum_int.FactoryInterfaces);
                 InterfacesLoaded = true;
@@ -290,9 +290,9 @@ namespace OleViewDotNet.Database
         /// <param name="refresh">Force the supported interface list to refresh</param>
         /// <returns>Returns true if supported interfaces were refreshed.</returns>
         /// <exception cref="Win32Exception">Thrown on error.</exception>
-        public bool LoadSupportedInterfaces(bool refresh, NtToken token)
+        public bool LoadSupportedInterfaces(bool refresh, NtToken token, COMServerType serverType)
         {
-            Task<bool> result = LoadSupportedInterfacesAsync(refresh, token);
+            Task<bool> result = LoadSupportedInterfacesAsync(refresh, token, serverType);
             result.Wait();
             if (result.IsFaulted)
             {

--- a/OleViewDotNet.Main/Forms/COMRegistryViewer.cs
+++ b/OleViewDotNet.Main/Forms/COMRegistryViewer.cs
@@ -1047,7 +1047,7 @@ namespace OleViewDotNet.Forms
                 node.Nodes.Add(wait_node);
                 try
                 {
-                    await clsid.LoadSupportedInterfacesAsync(bRefresh, null);
+                    await clsid.LoadSupportedInterfacesAsync(bRefresh, null, COMServerType.UnknownServer);
                     int interface_count = clsid.Interfaces.Count();
                     int factory_count = clsid.FactoryInterfaces.Count();
                     if (interface_count == 0 && factory_count == 0)

--- a/OleViewDotNet.Main/Forms/MainForm.cs
+++ b/OleViewDotNet.Main/Forms/MainForm.cs
@@ -141,7 +141,7 @@ namespace OleViewDotNet.Forms
 
             if (!ent.InterfacesLoaded)
             {
-                await ent.LoadSupportedInterfacesAsync(false, null);
+                await ent.LoadSupportedInterfacesAsync(false, null, COMServerType.UnknownServer);
             }
 
             IEnumerable<COMInterfaceInstance> intfs = factory ? ent.FactoryInterfaces : ent.Interfaces;
@@ -226,7 +226,7 @@ namespace OleViewDotNet.Forms
                     props.Add("CLSID", ent.Clsid.FormatGuid());
                     props.Add("Name", ent.Name);
                     props.Add("Server", ent.DefaultServer);
-                    await ent.LoadSupportedInterfacesAsync(false, null);
+                    await ent.LoadSupportedInterfacesAsync(false, null, COMServerType.UnknownServer);
 
                     if (class_factory)
                     {
@@ -357,7 +357,7 @@ namespace OleViewDotNet.Forms
                     props.Add("CLSID", ent.Clsid.FormatGuid());
                     props.Add("Name", ent.Name);
                     props.Add("Server", ent.DefaultServer);
-                    await ent.LoadSupportedInterfacesAsync(false, null);
+                    await ent.LoadSupportedInterfacesAsync(false, null, COMServerType.UnknownServer);
                     ints = ent.Interfaces.Select(i => m_registry.MapIidToInterface(i.Iid));
                 }
                 else

--- a/OleViewDotNet.Main/Forms/PropertiesControl.cs
+++ b/OleViewDotNet.Main/Forms/PropertiesControl.cs
@@ -445,7 +445,7 @@ namespace OleViewDotNet.Forms
             try
             {
                 ICOMClassEntry entry = (ICOMClassEntry)tabPageSupportedInterfaces.Tag;
-                await entry.LoadSupportedInterfacesAsync(true, null);
+                await entry.LoadSupportedInterfacesAsync(true, null, COMServerType.UnknownServer);
                 LoadInterfaceList(entry.Interfaces, listViewInterfaces);
                 LoadInterfaceList(entry.FactoryInterfaces, listViewFactoryInterfaces);
             }

--- a/OleViewDotNet.PowerShell/OleViewDotNet.psm1
+++ b/OleViewDotNet.PowerShell/OleViewDotNet.psm1
@@ -907,6 +907,8 @@ Get a COM class or Runtime class instance interfaces.
 This cmdlet enumerates the supported interfaces for a COM class or Runtime class and returns them.
 .PARAMETER ClassEntry
 The COM or Runtime classes to enumerate.
+.PARAMETER ServerType
+Specify a type of server to match against. If specified as UnknownServer will search DefaultServerType.
 .PARAMETER Refresh
 Specify to force the interfaces to be refreshed.
 .PARAMETER Factory
@@ -936,6 +938,7 @@ function Get-ComClassInterface {
     Param(
         [Parameter(Mandatory, Position = 0, ValueFromPipeline)]
         [OleViewDotNet.Database.ICOMClassEntry[]]$ClassEntry,
+        [OleViewDotNet.Database.COMServerType]$ServerType = "UnknownServer",
         [switch]$Refresh,
         [switch]$Factory,
         [switch]$NoQuery,
@@ -954,7 +957,7 @@ function Get-ComClassInterface {
                         $i++
                     }
                 }
-                $class.LoadSupportedInterfaces($Refresh, $Token) | Out-Null
+                $class.LoadSupportedInterfaces($Refresh, $Token, $ServerType) | Out-Null
             }
             if ($Factory) {
                 $class.FactoryInterfaces | Write-Output


### PR DESCRIPTION
Now Get-ComClassInterface tries to instantiate COM class for further querying implemented interfaces with CLSCTX derived from [DefaultServerType](https://github.com/tyranid/oleviewdotnet/blob/55b5cb0e48e7475e0c72e958300388a51ab1ccb2/OleViewDotNet.Main/Database/COMEnumerateInterfaces.cs#L512). But sometimes this results in error:

``` powershell
$UsoClass = Get-ComClass -Clsid B91D5831-B1BD-4608-8198-D72E155020F7                                                                                                                                                                                                                                                                                                                                                                                                                             Get-ComClassInterface -ClassEntry $UsoClass
Exception calling "LoadSupportedInterfaces" with "3" argument(s): "ClassFactory cannot supply requested class"
At C:\Users\User\Documents\MyRepo\oleviewdotnet\bin\Release\OleViewDotNet.psm1:960 char:17
+ ...             $class.LoadSupportedInterfaces($Refresh, $Token, $ServerT ...
+                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : NotSpecified: (:) [], MethodInvocationException
    + FullyQualifiedErrorId : Win32Exception
```

Error occurs due attempt to instantiate this COM-object in-proc because UpdateSessionOrchestrator's DefaultServerType is InProcServer32. And it could be cool if you can manually specify desired server type. With proposed fix it can look like:

``` powershell
Get-ComClassInterface -ClassEntry $UsoClass -ServerType LocalServer32

Name                 IID                                  Module               VTableOffset
----                 ---                                  ------               ------------
IMarshal             00000003-0000-0000-c000-000000000046                      0
IMarshal2            000001cf-0000-0000-c000-000000000046                      0
IUnknown             00000000-0000-0000-c000-000000000046                      0
IUpdateSessionOrc... 07f3afac-7c8a-4ce7-a5e0-3d24ee8a77e0                      0
IMoUsoOrchestrator   c57692f8-8f5f-47cb-9381-34329b40285a                      0
```

P.S.: In the future, it will be nice to add this parameter to UI, but I'm too lazy for this 